### PR TITLE
Use canonical phpdoc format

### DIFF
--- a/src/Executor/FilterTrait.php
+++ b/src/Executor/FilterTrait.php
@@ -38,7 +38,7 @@ trait FilterTrait
      */
     public function filter($target, array $parameters, array $operators, ExecutionContext $context)
     {
-        /* @var \Doctrine\DBAL\Query\QueryBuilder $target */
+        /** @var \Doctrine\DBAL\Query\QueryBuilder $target */
 
         $this->applyFilter($target, $parameters, $operators, $context);
 


### PR DESCRIPTION
https://docs.phpdoc.org/latest/references/phpdoc/basic-syntax.html

`/*` format should be used for text comments, not phpdoc